### PR TITLE
ツイートの形式を変換してエクスポートする機能の追加

### DIFF
--- a/opt/run.ipynb
+++ b/opt/run.ipynb
@@ -68,18 +68,17 @@
    "source": [
     "import pathlib\n",
     "import json\n",
+    "import pandas as pd\n",
     "\n",
     "read_path = pathlib.Path().joinpath(unzipped_directory_path, 'data', 'tweets.js')\n",
-    "write_path = tmp.joinpath('tweets.json')\n",
+    "write_path = tmp.joinpath('tweets.csv')\n",
     "\n",
-    "content = read_path.read_text(encoding='utf-8')\n",
-    "content = content.replace('window.YTD.tweets.part0 = ', '', 1)\n",
-    "write_path.write_text(content, encoding='utf-8')\n",
+    "raw_file_content = read_path.read_text(encoding='utf-8')\n",
+    "json_formatted_file_content = raw_file_content.replace('window.YTD.tweets.part0 = ', '', 1)\n",
+    "df = pd.json_normalize(json.loads(json_formatted_file_content))\n",
     "\n",
-    "with open(write_path, encoding='utf-8') as f:\n",
-    "    df = json.load(f)\n",
-    "\n",
-    "print(len(df))"
+    "df.to_csv(write_path, encoding='utf-8')\n",
+    "df"
    ]
   }
  ],


### PR DESCRIPTION
#9

- [x] CSV形式に変換
- [x] ~~マストドンにインポートできる形式に変換~~ → #42
- [x] 機械学習に読み込ませられる形式に変換 → 最も扱いやすい形式であるかは何とも言えない（データの取捨選択をせずすべて保存しているため）が、CSV形式であることでそれなりに扱いやすいものと思われる

JSファイル内のデータをCSVファイルに変換して出力するよう変更。JSONファイルを中間生成していたが理由がないので取りやめ